### PR TITLE
Adding decline and reset button

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Primarily for use at NI. If you also use Review Board, it is possible that this 
 ### Neat new features!
 
 - Categories reviews into Incomplete, Reviewed, and Ship It groups
+- Buttons to decline themselves and others if they are on vacation or unnecessary on the review.
+- Buttons to get reset on a review (aka. re-added or "please see these changes again")
 - Adds an icon to navigate to file from its diff
 - Lets you click anywhere in the header to expand/collapse a comment
 

--- a/src/ni-reviewboard.user.js
+++ b/src/ni-reviewboard.user.js
@@ -119,28 +119,25 @@
           if (!review.public) continue;
 
           const username = review.links.user.title;
-          const userUrl = review.links.user.href.replace('https://review-board.natinst.com/api', '');
           const thread = document.querySelector(`.review[data-review-id="${review.id}"]`);
+          const span = userSpans[username];
           let threadLabel;
           let threadHeader;
-
-          const span = userSpans[username];
 
           if (username === 'prebuild') {
             // Record the vote of a build user.
 
-            const comment = review.body_top;
-            let match;
-            if (span.innerHTML === ' 💬') {
+            if (prebuildThreads.length === 1) {
               span.innerHTML = username;
             }
 
+            let match;
+            const comment = review.body_top;
+
             if (comment.match(/going to check/)) {
               span.innerHTML += ' 💬';
-              if (thread) {
-                for (const element of prebuildThreads) {
-                  element.classList.add('old');
-                }
+              for (const element of prebuildThreads) {
+                element.classList.add('old');
               }
               prebuildThreads = [];
             // eslint-disable-next-line no-cond-assign
@@ -160,18 +157,16 @@
               span.innerHTML += '<br> ⤷ ❓';
             }
 
-            if (thread) prebuildThreads.push(thread);
+            prebuildThreads.push(thread);
           } else {
             // Record the vote of a non-build user.
             span.innerHTML += review.ship_it ? ' ✅' : ' 💬';
           }
 
           // Annotate the review on the HTML page.
-          if (thread) {
-            thread.classList.add(eus.toCss(userUrl));
-            if (threadLabel) thread.querySelector('.labels-container').insertAdjacentHTML('beforeend', threadLabel);
-            if (threadHeader) thread.querySelector('.header a.user').insertAdjacentHTML('beforeend', threadHeader);
-          }
+          thread.classList.add(`users-${eus.toCss(username)}`);
+          if (threadLabel) thread.querySelector('.labels-container').insertAdjacentHTML('beforeend', threadLabel);
+          if (threadHeader) thread.querySelector('.header a.user').insertAdjacentHTML('beforeend', threadHeader);
         }
 
         // Annotates the `.niconfig` owner review block with approvals.
@@ -179,9 +174,8 @@
         if (owners && owners.innerText.includes('.niconfig Owners')) {
           let ownersHtml = owners.innerHTML;
 
-          const ownersText = owners.innerText.split('\n').filter(l => l.match(/^\.niconfig/));
           const rolesToUsers = {};
-          for (const line of ownersText) {
+          for (const line of owners.innerText.split('\n').filter(l => l.match(/^\.niconfig/))) {
             const [role, users] = line.replace('.niconfig', '').replace(/\s/gi, '').split(':', 2);
             rolesToUsers[role.toLowerCase()] = users.split(',');
           }

--- a/src/ni-reviewboard.user.js
+++ b/src/ni-reviewboard.user.js
@@ -220,7 +220,7 @@
           }
         }
 
-        eus.globalSession.on(targetPeopleAndGroups, '.user-action.decline', 'click', async (event, button) => {
+        eus.globalSession.on(targetPeopleAndGroups, '.user-action.decline', 'click', (event, button) => {
           event.preventDefault();
 
           const { username } = button.dataset;
@@ -242,7 +242,7 @@
           });
         });
 
-        eus.globalSession.on(targetPeopleAndGroups, '.user-action.reset', 'click', async (event, button) => {
+        eus.globalSession.on(targetPeopleAndGroups, '.user-action.reset', 'click', (event, button) => {
           event.preventDefault();
 
           const { username } = button.dataset;

--- a/src/ni-reviewboard.user.js
+++ b/src/ni-reviewboard.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name         More Awesome NI Review Board
-// @version      1.8.0
+// @version      1.8.1
 // @namespace    https://www.ni.com
 // @author       Alejandro Barreto (National Instruments)
 // @license      MIT
@@ -75,7 +75,6 @@
         });
       }
 
-
       // Annotate approval details on users and groups.
       eus.globalSession.onFirst(document, '#fieldset_reviewers_body', async (targetPeopleAndGroups) => {
         const groupsField = document.getElementById('field_target_groups');
@@ -139,8 +138,8 @@
             if (comment.match(/going to check/)) {
               user.vote = '🔨';
               user.details = '';
-              for (const element of prebuildThreads) {
-                element.classList.add('old');
+              for (const prebuildThread of prebuildThreads) {
+                prebuildThread.classList.add('old');
               }
               prebuildThreads = [];
             // eslint-disable-next-line no-cond-assign
@@ -232,6 +231,7 @@
           swal.fire({
             input: 'text',
             title: `Declining ${username}`,
+            text: 'They will be crossed out in the list but will still receive emails. Optional decline reason:',
             inputPlaceholder: defaultReason,
             confirmButtonText: 'Decline',
             confirmButtonColor: '#e40',
@@ -255,6 +255,7 @@
           swal.fire({
             input: 'text',
             title: `Resetting ${username}`,
+            text: 'Their status will be reset and they will receive an email. Optional reset reason:',
             inputPlaceholder: defaultReason,
             confirmButtonText: 'Reset',
             confirmButtonColor: '#e40',

--- a/src/ni-reviewboard.user.js
+++ b/src/ni-reviewboard.user.js
@@ -126,6 +126,7 @@
           const user = users[username];
 
           const thread = document.querySelector(`.review[data-review-id="${review.id}"]`);
+          let threadClass;
           let threadLabel;
           let threadSubtitle;
 
@@ -171,10 +172,12 @@
             if (match = comment.match(/^Declining\s+(?<username>[\w-_]+)\b/i)) {
               const declinedUser = users[match.groups.username];
               if (declinedUser) declinedUser.vote = '✖️';
+              threadClass = 'user-action';
             // eslint-disable-next-line no-cond-assign
             } else if (match = comment.match(/^Resetting\s+(?<username>[\w-_]+)\b/i)) {
-              const declinedUser = users[match.groups.username];
-              if (declinedUser) declinedUser.vote = '';
+              const resetUser = users[match.groups.username];
+              if (resetUser) resetUser.vote = '';
+              threadClass = 'user-action';
             } else {
               user.vote = review.ship_it ? '✅' : '💬';
             }
@@ -182,6 +185,7 @@
 
           // Annotate the review on the HTML page.
           thread.classList.add(`users-${eus.toCss(username)}`);
+          if (threadClass) thread.classList.add(threadClass);
           if (threadLabel) thread.querySelector('.labels-container').insertAdjacentHTML('beforeend', threadLabel);
           if (threadSubtitle) thread.querySelector('.header a.user').insertAdjacentHTML('beforeend', ` &mdash; ${threadSubtitle}`);
         }
@@ -255,21 +259,19 @@
         });
 
         // Annotate groups on the right.
-        // for (const group of reviewRequest.target_groups) {
-        //   // Fetch each group in parallel.
-        //   fetch(`${group.href}/users/`)
-        //     .then(response => response.json())
-        //     .then(groupMembers => {
-        //       const groupUrl = `/groups/${group.title}/`;
-        //       for (const user of groupMembers.users) {
-        //         const vote = users[user.username].span;
-        //         if (!vote) continue;
-        //         for (const link of document.querySelectorAll(`#review_request a[href="${groupUrl}"]`)) {
-        //           link.insertAdjacentHTML('beforeend', `<br>⤷ ${user.outerHTML}${vote}`); // TODO: Test this may not work.
-        //         }
-        //       }
-        //     });
-        // }
+        for (const group of reviewRequest.target_groups) {
+          // Fetch each group in parallel.
+          fetch(`${group.href}/users/`)
+            .then(response => response.json())
+            .then(groupMembers => {
+              const groupUrl = `/groups/${group.title}/`;
+              const link = groupsField.querySelector(`a[href="${groupUrl}"]`);
+              for (const groupMember of groupMembers.users) {
+                const user = users[groupMember.username];
+                if (user) link.insertAdjacentHTML('beforeend', `<br>⤷ ${user.span.outerHTML}`);
+              }
+            });
+        }
       });
     }
   });
@@ -719,7 +721,7 @@
     /* Color user comments differently. */
     .review .header { background: #ccf; }
     .changedesc .header { background: #eee; }
-    .review.users-prebuild .header { background: #eee; }
+    .review.users-prebuild .header, .review.user-action .header { background: #eee; }
     .review.users-prebuild.old { opacity: 0.3; }
 
     /* Support reordering the review feed newest-first. */

--- a/src/ni-reviewboard.user.js
+++ b/src/ni-reviewboard.user.js
@@ -224,38 +224,44 @@
           event.preventDefault();
 
           const { username } = button.dataset;
-          const result = await swal.fire({
+          const defaultReason = 'Not needed for these changes.';
+          swal.fire({
             input: 'text',
             title: `Declining ${username}`,
-            inputPlaceholder: 'Provide a reason (or leave empty)...',
+            inputPlaceholder: defaultReason,
+            confirmButtonText: 'Decline',
+            confirmButtonColor: '#e40',
             showCancelButton: true,
+            showLoaderOnConfirm: true,
+            preConfirm: async reason => {
+              await postReview(requestId, `Declining ${username}: ${reason || defaultReason}`);
+              // eslint-disable-next-line no-restricted-globals
+              location.reload();
+              await eus.sleep(100000); // Reload isn't blocking, so let's sleep while we wait for the page to reload.
+            },
           });
-          if (result.dismiss) return;
-
-          const reason = result.value.trim() || 'No reason specified.';
-          await postReview(requestId, `Declining ${username}: ${reason}`);
-
-          // eslint-disable-next-line no-restricted-globals
-          location.reload();
         });
 
         eus.globalSession.on(targetPeopleAndGroups, '.user-action.reset', 'click', async (event, button) => {
           event.preventDefault();
 
           const { username } = button.dataset;
-          const result = await swal.fire({
+          const defaultReason = 'Please review these changes again.';
+          swal.fire({
             input: 'text',
             title: `Resetting ${username}`,
-            inputPlaceholder: 'Provide a reason (or leave empty)...',
+            inputPlaceholder: defaultReason,
+            confirmButtonText: 'Reset',
+            confirmButtonColor: '#e40',
             showCancelButton: true,
+            showLoaderOnConfirm: true,
+            preConfirm: async reason => {
+              await postReview(requestId, `Resetting ${username}: ${reason || defaultReason}`);
+              // eslint-disable-next-line no-restricted-globals
+              location.reload();
+              await eus.sleep(100000); // Reload isn't blocking, so let's sleep while we wait for the page to reload.
+            },
           });
-          if (result.dismiss) return;
-
-          const reason = result.value.trim() || 'No reason specified.';
-          await postReview(requestId, `Resetting ${username}: ${reason}`);
-
-          // eslint-disable-next-line no-restricted-globals
-          location.reload();
         });
 
         // Annotate groups on the right.

--- a/src/ni-reviewboard.user.js
+++ b/src/ni-reviewboard.user.js
@@ -188,8 +188,12 @@
 
         for (const user of Object.values(users)) {
           console.log(user);
-          if (user.vote === '✖️') user.span.classList.add('declined');
-          user.span.innerHTML += `${user.info.title} ${user.vote}${user.details}`;
+          if (user.vote === '✖️') {
+            user.span.classList.add('declined');
+            user.span.innerHTML += `${user.info.title}${user.details}`;
+          } else {
+            user.span.innerHTML += `${user.info.title} ${user.vote}${user.details}`;
+          }
         }
 
         // Annotates the `.niconfig` owner review block with approvals.
@@ -733,7 +737,7 @@
       float: right;
       padding: 2px 5px;
       font-size: 100%;
-      opacity: 0;
+      opacity: 0.15;
       transition: 0.2s;
       border: none;
       background: none;

--- a/src/ni-reviewboard.user.js
+++ b/src/ni-reviewboard.user.js
@@ -192,13 +192,14 @@
           if (threadSubtitle) thread.querySelector('.header a.user').insertAdjacentHTML('beforeend', ` &mdash; ${threadSubtitle}`);
         }
 
+        // Populate the span that has each user's name and vote.
         for (const user of Object.values(users)) {
           user.span.classList.add('user-status');
           if (user.vote === '✖️') {
             user.span.classList.add('declined');
-            user.span.innerHTML += `${user.info.title}${user.details}`;
+            user.span.innerHTML += `${user.username}${user.details}`;
           } else {
-            user.span.innerHTML += `${user.info.title} ${user.vote}${user.details}`;
+            user.span.innerHTML += `${user.username} ${user.vote}${user.details}`;
           }
         }
 
@@ -222,6 +223,7 @@
           }
         }
 
+        // Handle clicks to reviewer decline buttons.
         eus.globalSession.on(targetPeopleAndGroups, '.user-action.decline', 'click', (event, button) => {
           event.preventDefault();
 
@@ -244,6 +246,7 @@
           });
         });
 
+        // Handle clicks to reviewer reset buttons.
         eus.globalSession.on(targetPeopleAndGroups, '.user-action.reset', 'click', (event, button) => {
           event.preventDefault();
 

--- a/src/ni-reviewboard.user.js
+++ b/src/ni-reviewboard.user.js
@@ -21,7 +21,7 @@
 /* global eus, swal */
 
 (function () {
-  eus.globalSession.onFirst(document, 'body', async () => {
+  eus.globalSession.onFirst(document, 'body', () => {
     eus.registerCssClassConfig(document.body, 'Select theme', 'theme', 'ni-light', {
       'ni-dark': 'Dark',
       'ni-middle': 'Middle',
@@ -115,7 +115,7 @@
             info: user,
             span,
             vote: '',
-            details: ''
+            details: '',
           };
         }
 
@@ -168,10 +168,11 @@
             prebuildThreads.push(thread);
           } else {
             // Record the vote of a non-build user.
-            // eslint-disable-next-line no-cond-assign
+            // eslint-disable-next-line no-lonely-if, no-cond-assign
             if (match = comment.match(/^Declining\s+(?<username>[\w-_]+)\b/i)) {
               const declinedUser = users[match.groups.username];
               if (declinedUser) declinedUser.vote = '✖️';
+            // eslint-disable-next-line no-cond-assign
             } else if (match = comment.match(/^Resetting\s+(?<username>[\w-_]+)\b/i)) {
               const declinedUser = users[match.groups.username];
               if (declinedUser) declinedUser.vote = '';
@@ -187,7 +188,6 @@
         }
 
         for (const user of Object.values(users)) {
-          console.log(user);
           if (user.vote === '✖️') {
             user.span.classList.add('declined');
             user.span.innerHTML += `${user.info.title}${user.details}`;
@@ -230,7 +230,7 @@
         eus.globalSession.on(targetPeopleAndGroups, '.decline-button', 'click', async (event, button) => {
           event.preventDefault();
 
-          const username = button.dataset.username;
+          const { username } = button.dataset;
           const result = await swal.fire({
             input: 'text',
             title: `Declining ${username}`,
@@ -241,6 +241,8 @@
 
           const reason = result.value.trim() || 'No reason specified.';
           await postReview(requestId, `Declining ${username}: ${reason}`);
+
+          // eslint-disable-next-line no-restricted-globals
           location.reload();
         });
 

--- a/src/ni-reviewboard.user.js
+++ b/src/ni-reviewboard.user.js
@@ -120,14 +120,13 @@
 
           const username = review.links.user.title;
           const userUrl = review.links.user.href.replace('https://review-board.natinst.com/api', '');
-          const userIsPrebuild = userUrl === '/users/prebuild/';
           const thread = document.querySelector(`.review[data-review-id="${review.id}"]`);
-          let threadLabel = null;
-          let threadHeader = null;
+          let threadLabel;
+          let threadHeader;
 
           const span = userSpans[username];
 
-          if (userIsPrebuild) {
+          if (username === 'prebuild') {
             // Record the vote of a build user.
 
             const comment = review.body_top;
@@ -160,10 +159,11 @@
             } else {
               span.innerHTML += '<br> ⤷ ❓';
             }
+
+            if (thread) prebuildThreads.push(thread);
           } else {
             // Record the vote of a non-build user.
-            const vote = review.ship_it ? ' ✅' : ' 💬';
-            span.innerHTML += vote;
+            span.innerHTML += review.ship_it ? ' ✅' : ' 💬';
           }
 
           // Annotate the review on the HTML page.
@@ -172,8 +172,6 @@
             if (threadLabel) thread.querySelector('.labels-container').insertAdjacentHTML('beforeend', threadLabel);
             if (threadHeader) thread.querySelector('.header a.user').insertAdjacentHTML('beforeend', threadHeader);
           }
-
-          if (userIsPrebuild) prebuildThreads.push(thread);
         }
 
         // Annotates the `.niconfig` owner review block with approvals.

--- a/src/ni-reviewboard.user.js
+++ b/src/ni-reviewboard.user.js
@@ -219,9 +219,22 @@
         }
 
         eus.globalSession.on(targetPeopleAndGroups, 'button.decline-button', 'click', async (event, button) => {
-          await postReview(requestId, `Declining: ${button.dataset.username}`);
+          event.preventDefault();
+
+          const username = button.dataset.username;
+
+          const result = await swal.fire({
+            input: 'text',
+            title: `Declining ${username}`,
+            inputPlaceholder: 'Provide a reason (or leave empty)...',
+            showCancelButton: true,
+          });
+          if (result.dismiss) return;
+
+          const reason = result.value.trim() || 'No reason specified.';
+          await postReview(requestId, `Declining **${username}**: ${reason}`);
+
           location.reload();
-          event.stopPropagation();
         });
 
         // Annotate groups on the right.

--- a/src/ni-reviewboard.user.js
+++ b/src/ni-reviewboard.user.js
@@ -144,17 +144,19 @@
               }
               prebuildThreads = [];
             // eslint-disable-next-line no-cond-assign
-            } else if (match = comment.match(/successfully built the changes on (?<platform>[\w-_]*)/i)) {
+            } else if (match = comment.match(/successfully built the changes on ([\w-_]*)/i)) {
+              const platform = match[1];
               user.vote = '';
-              user.details += `<br> ⤷ ${match.groups.platform} ✅`;
+              user.details += `<br> ⤷ ${platform} ✅`;
               threadLabel = '<label class="ship-it-label">Pass</label>';
-              threadSubtitle = match.groups.platform;
+              threadSubtitle = platform;
             // eslint-disable-next-line no-cond-assign
-            } else if (match = comment.match(/^Build failed on (?<platform>[\w-_]*)/i)) {
+            } else if (match = comment.match(/^Build failed on ([\w-_]*)/i)) {
+              const platform = match[1];
               user.vote = '';
-              user.details += `<br> ⤷ ${match.groups.platform} ❌`;
+              user.details += `<br> ⤷ ${platform} ❌`;
               threadLabel = '<label class="fix-it-label">Fail</label>';
-              threadSubtitle = match.groups.platform;
+              threadSubtitle = platform;
             } else if (comment.match(/fail/i)) {
               user.vote = '';
               user.details += '<br> ⤷ ❌';
@@ -169,13 +171,13 @@
             // Record the vote of a non-build user.
 
             // eslint-disable-next-line no-lonely-if, no-cond-assign
-            if (match = comment.match(/^Declining\s+(?<username>[\w-_]+)\b/i)) {
-              const declinedUser = users[match.groups.username];
+            if (match = comment.match(/^Declining\s+([\w-_]+)\b/i)) {
+              const declinedUser = users[match[1]];
               if (declinedUser) declinedUser.vote = '✖️';
               threadClass = 'user-action';
             // eslint-disable-next-line no-cond-assign
-            } else if (match = comment.match(/^Resetting\s+(?<username>[\w-_]+)\b/i)) {
-              const resetUser = users[match.groups.username];
+            } else if (match = comment.match(/^Resetting\s+([\w-_]+)\b/i)) {
+              const resetUser = users[match[1]];
               if (resetUser) resetUser.vote = '';
               threadClass = 'user-action';
             } else {

--- a/src/ni-reviewboard.user.js
+++ b/src/ni-reviewboard.user.js
@@ -109,7 +109,7 @@
         for (const user of reviewRequest.target_people) {
           const username = user.title;
           const span = document.createElement('span');
-          span.href = user.href.replace('/api/', '/');
+          span.classList.add('user-status');
           users[username] = {
             username,
             info: user,
@@ -170,7 +170,7 @@
           } else {
             // Record the vote of a non-build user.
             if (comment.match(/^I decline this review\./i)) {
-              user.vote = '💨';
+              user.vote = '';
               user.class = 'declined';
             } else {
               user.vote = review.ship_it ? '✅' : '💬';
@@ -214,11 +214,13 @@
             const link = peopleField.querySelector(`a[href*="${username}"]`);
             link.innerText = '';
             link.appendChild(users[username].span);
-            link.insertAdjacentHTML('afterBegin', `<button class="decline-button" data-username="${username}">X</button>`);
+            if (username !== 'prebuild') {
+              link.insertAdjacentHTML('afterBegin', `<button class="decline-button" data-username="${username}">✖️</button>`);
+            }
           }
         }
 
-        eus.globalSession.on(targetPeopleAndGroups, 'button.decline-button', 'click', async (event, button) => {
+        eus.globalSession.on(targetPeopleAndGroups, '.decline-button', 'click', async (event, button) => {
           event.preventDefault();
 
           const username = button.dataset.username;
@@ -717,13 +719,25 @@
     /* Fix a bug where the page does not use up all available page width. */
     #container { width: 100%; }
 
-    a.user .declined {
-      opacity: 0.2;
+    #field_target_people {
+      max-width: initial !important;
+      width: 100%;
     }
-    button.decline-button {
+    .user-status.declined {
+      opacity: 0.35;
+      text-decoration: line-through;
+    }
+    .decline-button {
       float: right;
-      padding: 1px 2px;
+      padding: 2px 5px;
       font-size: 100%;
+      opacity: 0;
+      transition: 0.2s;
+      border: none;
+      background: none;
+    }
+    #field_target_people:hover .decline-button {
+      opacity: 0.8;
     }
   `);
 }());


### PR DESCRIPTION
## Why do we need this?

We want reviewers to be able to decline themselves and others if they are on vacation or unnecessary on the review. If you get declined, you also want to be able to get reset (aka. re-added).

## What does this change do?

Add decline and reset buttons. These post specially formatted comments on the review request that we later parse to add status UI for these users.

![image](https://user-images.githubusercontent.com/3143819/83913290-eb894000-a734-11ea-93dc-b32df2434724.png)

Declined users stay on the review request since only the owner of the request can remove them (because of permissions). They also get emails on declines and resets -- a good thing; we want to let our reviewers know when this happens to them so they can react if needed.

## How was this tested?

Manual testing on Chrome and FireFox.

## Checklist

If applicable:

- [x] Runs in latest stable Chrome and Firefox without Javascript errors
- [x] Does not report any issues with `eslint` (run `npm run build` -- the PR build will also check this)
- [x] Increment version following [semver](https://semver.org/)
- [x] All `@require` and `@resource` URLs must have SRI ([use this hashing tool](https://www.srihash.org/))
- [x] Blocks of code are commented
- [x] Included a screenshot in the PR
- [x] Added docs to `README.md`
- [ ] Linked issues